### PR TITLE
Migrate to new lager + OTP 20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+ebin/
+.git
+deps
+.rebar/

--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
 {cover_enabled, true}.
 
 {deps, [
-       {lager, "(2.1|2.0|1.0|1.2).*", {git, "git://github.com/basho/lager", {branch, "master"}}},
+       {lager, "(3.5|2.0|1.0|1.2).*", {git, "git://github.com/erlang-lager/lager", {branch, "master"}}},
        {'folsom', ".*", {git, "git://github.com/boundary/folsom", {branch, "master"}}}
        ]
 }.

--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
 {cover_enabled, true}.
 
 {deps, [
-       {lager, "(2.0|1.0|1.2|3.5).*", {git, "git://github.com/erlang-lager/lager", {branch, "master"}}},
+       {lager, "(2.1|2.0|1.0|1.2|3.5).*", {git, "git://github.com/erlang-lager/lager", {branch, "master"}}},
        {'folsom', ".*", {git, "git://github.com/boundary/folsom", {branch, "master"}}}
        ]
 }.

--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
 {cover_enabled, true}.
 
 {deps, [
-       {lager, "(3.5|2.0|1.0|1.2).*", {git, "git://github.com/erlang-lager/lager", {branch, "master"}}},
+       {lager, "(2.0|1.0|1.2|3.5).*", {git, "git://github.com/erlang-lager/lager", {branch, "master"}}},
        {'folsom', ".*", {git, "git://github.com/boundary/folsom", {branch, "master"}}}
        ]
 }.


### PR DESCRIPTION
This change should not destroy builds that rely on old lager, otherwise the master dependency would've already exploded